### PR TITLE
RecordIOOperator refactor

### DIFF
--- a/mesos-rxjava-recordio/src/main/java/org/apache/mesos/rx/java/recordio/ConcatenatedInputStream.java
+++ b/mesos-rxjava-recordio/src/main/java/org/apache/mesos/rx/java/recordio/ConcatenatedInputStream.java
@@ -1,0 +1,57 @@
+package org.apache.mesos.rx.java.recordio;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.io.ByteArrayInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+final class ConcatenatedInputStream extends FilterInputStream {
+
+    @NotNull
+    private static final InputStream EMPTY_STREAM = new ByteArrayInputStream(new byte[0]);
+
+    @NotNull
+    private final Queue<InputStream> streams = new ArrayDeque<>();
+
+    public ConcatenatedInputStream() {
+        super(EMPTY_STREAM);
+    }
+
+    public void append(@NotNull final InputStream inputStream) {
+        streams.add(inputStream);
+    }
+
+    @Override
+    public int read() throws IOException {
+        return handleEndOfStream(super::read);
+    }
+
+    @Override
+    public int read(@NotNull final byte[] b, final int off, final int len) throws IOException {
+        return handleEndOfStream(() -> super.read(b, off, len));
+    }
+
+    private int handleEndOfStream(final IOIntSupplier method) throws IOException {
+        int result;
+
+        while ((result = method.getAsInt()) == -1) {
+            in = streams.poll();
+
+            if (in == null) {
+                in = EMPTY_STREAM;
+                break;
+            }
+        }
+
+        return result;
+    }
+
+    private interface IOIntSupplier {
+        int getAsInt() throws IOException;
+    }
+
+}

--- a/mesos-rxjava-recordio/src/main/java/org/apache/mesos/rx/java/recordio/MessageStream.java
+++ b/mesos-rxjava-recordio/src/main/java/org/apache/mesos/rx/java/recordio/MessageStream.java
@@ -1,0 +1,119 @@
+package org.apache.mesos.rx.java.recordio;
+
+import com.google.common.base.Charsets;
+import io.netty.buffer.ByteBuf;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+final class MessageStream {
+
+    @NotNull
+    private static final Logger LOGGER = LoggerFactory.getLogger(MessageStream.class);
+
+    /**
+     * Maximum number of base-10 digits in a uint64
+     */
+    private static final int MESSAGE_SIZE_MAX_LENGTH = 20;
+
+    @NotNull
+    private final InputStream source;
+
+    private int messageSizeBytesRead = 0;
+
+    /**
+     * The message size from the stream is provided as a base-10 String representation of an
+     * unsigned 64 bit integer (uint64). Since there is a possibility (since the spec isn't
+     * formal on this, and the HTTP chunked Transfer-Encoding applied to the data stream can
+     * allow chunks to be any size) this field functions as the bytes that have been read
+     * since the end of the last message. When the next '\n' is encountered in the byte
+     * stream, these bytes are converted to a UTF-8 String. This string representation is
+     * then read as a {@code long} using {@link Long#valueOf(String, int)}.
+     */
+    @NotNull
+    private final byte[] messageSizeBytes = new byte[MESSAGE_SIZE_MAX_LENGTH];
+
+    /**
+     * The number of bytes in the encoding is specified as an unsigned (uint64)
+     * However, since arrays in java are addressed and indexed by int we drop the
+     * precision early so that working with the arrays is easier.
+     * Also, a byte[Integer.MAX_VALUE] is 2gb so I seriously doubt we'll be receiving
+     * a message that large.
+     */
+    private int remainingBytesForMessage = 0;
+
+    /**
+     * The allocated {@code byte[]} for the current message being read from the stream.
+     * It is null until the first message is read, and is reassigned for each new message.
+     */
+    @Nullable
+    private byte[] messageBytes;
+
+    public MessageStream(final @NotNull InputStream source) {
+        this.source = source;
+    }
+
+    /**
+     * Gets the next message from this stream, if possible.
+     *
+     * @return the next complete message from the front of this stream, or {@code null} if not enough data is
+     * available.
+     * @throws IOException if an error occurs when reading data from the appended {@link ByteBuf}s.
+     */
+    @Nullable
+    public byte[] next() throws IOException {
+        if (remainingBytesForMessage == 0) {
+
+            while (true) {
+                int i = source.read();
+                if (i == -1) {
+                    return null;
+                }
+
+                byte b = (byte) i;
+                if (b == (byte) '\n') {
+                    break;
+                }
+
+                try {
+                    messageSizeBytes[messageSizeBytesRead++] = b;
+                } catch (ArrayIndexOutOfBoundsException e) {
+                    String error = "Message size field exceeds limit of " + messageSizeBytes.length + " bytes";
+                    throw new IllegalStateException(error, e);
+                }
+            }
+
+            final String messageSizeString = new String(messageSizeBytes, 0, messageSizeBytesRead, Charsets.UTF_8);
+            final long messageSize = Long.valueOf(messageSizeString);
+            messageSizeBytesRead = 0;
+
+            if (messageSize > Integer.MAX_VALUE) {
+                LOGGER.warn("specified message size ({}) is larger than Integer.MAX_VALUE. Value will be truncated to int");
+                remainingBytesForMessage = Integer.MAX_VALUE;
+                // TODO: Possibly make this more robust to account for things larger than 2g
+            } else {
+                remainingBytesForMessage = (int) messageSize;
+            }
+
+            messageBytes = new byte[remainingBytesForMessage];
+        }
+
+        if (messageBytes != null) {
+            final int startIndex = messageBytes.length - remainingBytesForMessage;
+            final int bytesRead = source.read(messageBytes, startIndex, remainingBytesForMessage);
+
+            if (bytesRead == -1) {
+                return null;
+            }
+
+            remainingBytesForMessage -= bytesRead;
+        }
+
+        return (remainingBytesForMessage == 0) ? messageBytes : null;
+    }
+
+}

--- a/mesos-rxjava-recordio/src/main/java/org/apache/mesos/rx/java/recordio/RecordIOOperator.java
+++ b/mesos-rxjava-recordio/src/main/java/org/apache/mesos/rx/java/recordio/RecordIOOperator.java
@@ -17,19 +17,12 @@
 package org.apache.mesos.rx.java.recordio;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Charsets;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufInputStream;
 import org.jetbrains.annotations.NotNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import rx.Observable.Operator;
 import rx.Subscriber;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.SequenceInputStream;
 
 /**
  * An {@link Operator} that can be applied to a stream of {@link ByteBuf} and produce
@@ -66,7 +59,11 @@ public final class RecordIOOperator implements Operator<byte[], ByteBuf> {
         @NotNull
         final Subscriber<? super byte[]> child;
 
-        private final @NotNull MessageStream messageStream = new MessageStream();
+        @NotNull
+        private final ConcatenatedInputStream pendingInput = new ConcatenatedInputStream();
+
+        @NotNull
+        private final MessageStream messageStream = new MessageStream(pendingInput);
 
         RecordIOSubscriber(@NotNull final Subscriber<? super byte[]> child) {
             super(child);
@@ -91,7 +88,7 @@ public final class RecordIOOperator implements Operator<byte[], ByteBuf> {
         @Override
         public void onNext(final ByteBuf buf) {
             try {
-                messageStream.append(buf);
+                pendingInput.append(new ByteBufInputStream(buf));
 
                 byte[] message;
                 while ((message = messageStream.next()) != null) {
@@ -114,109 +111,5 @@ public final class RecordIOOperator implements Operator<byte[], ByteBuf> {
 
     }
 
-
-    private static final class MessageStream {
-
-        private static final @NotNull Logger LOGGER = LoggerFactory.getLogger(MessageStream.class);
-
-        /** Maximum number of base-10 digits in a uint64 */
-        private static final int MESSAGE_SIZE_MAX_LENGTH = 20;
-
-        private @NotNull InputStream concatenatedInput = new ByteArrayInputStream(new byte[0]);
-
-        private int messageSizeBytesRead = 0;
-
-        /**
-         * The message size from the stream is provided as a base-10 String representation of an
-         * unsigned 64 bit integer (uint64). Since there is a possibility (since the spec isn't
-         * formal on this, and the HTTP chunked Transfer-Encoding applied to the data stream can
-         * allow chunks to be any size) this field functions as the bytes that have been read
-         * since the end of the last message. When the next '\n' is encountered in the byte
-         * stream, these bytes are converted to a UTF-8 String. This string representation is
-         * then read as a {@code long} using {@link Long#valueOf(String, int)}.
-         */
-        private final @NotNull byte[] messageSizeBytes = new byte[MESSAGE_SIZE_MAX_LENGTH];
-
-        /**
-         * The number of bytes in the encoding is specified as an unsigned (uint64)
-         * However, since arrays in java are addressed and indexed by int we drop the
-         * precision early so that working with the arrays is easier.
-         * Also, a byte[Integer.MAX_VALUE] is 2gb so I seriously doubt we'll be receiving
-         * a message that large.
-         */
-        private int remainingBytesForMessage = 0;
-
-        /**
-         * The allocated {@code byte[]} for the current message being read from the stream.
-         * It is null until the first message is read, and is reassigned for each new message.
-         */
-        private byte[] messageBytes;
-
-        /**
-         * Appends the contents of {@code buf} to the end of this stream.
-         *
-         * @param buf The {@link ByteBuf} to append.
-         */
-        public void append(final ByteBuf buf) {
-            concatenatedInput = new SequenceInputStream(concatenatedInput, new ByteBufInputStream(buf));
-        }
-
-        /**
-         * Gets the next message from this stream, if possible.
-         *
-         * @return the next complete message from the front of this stream, or {@code null} if not enough data is
-         *     available.
-         * @throws IOException if an error occurs when reading data from the appended {@link ByteBuf}s.
-         */
-        public byte[] next() throws IOException {
-            if (remainingBytesForMessage == 0) {
-
-                while (true) {
-                    int i = concatenatedInput.read();
-                    if (i == -1) {
-                        return null;
-                    }
-
-                    byte b = (byte) i;
-                    if (b == (byte) '\n') {
-                        break;
-                    }
-
-                    try {
-                        messageSizeBytes[messageSizeBytesRead++] = b;
-                    } catch (ArrayIndexOutOfBoundsException e) {
-                        String error = "Message size field exceeds limit of " + messageSizeBytes.length + " bytes";
-                        throw new IllegalStateException(error, e);
-                    }
-                }
-
-                final String messageSizeString = new String(messageSizeBytes, 0, messageSizeBytesRead, Charsets.UTF_8);
-                final long messageSize = Long.valueOf(messageSizeString);
-                messageSizeBytesRead = 0;
-
-                if (messageSize > Integer.MAX_VALUE) {
-                    LOGGER.warn("specified message size ({}) is larger than Integer.MAX_VALUE. Value will be truncated to int");
-                    remainingBytesForMessage = Integer.MAX_VALUE;
-                    // TODO: Possibly make this more robust to account for things larger than 2g
-                } else {
-                    remainingBytesForMessage = (int) messageSize;
-                }
-
-                messageBytes = new byte[remainingBytesForMessage];
-            }
-
-            final int startIndex = messageBytes.length - remainingBytesForMessage;
-            final int bytesRead = concatenatedInput.read(messageBytes, startIndex, remainingBytesForMessage);
-
-            if (bytesRead == -1) {
-                concatenatedInput = new ByteArrayInputStream(new byte[0]);
-                return null;
-            }
-
-            remainingBytesForMessage -= bytesRead;
-            return (remainingBytesForMessage == 0) ? messageBytes : null;
-        }
-
-    }
 
 }

--- a/mesos-rxjava-recordio/src/main/java/org/apache/mesos/rx/java/recordio/RecordIOOperator.java
+++ b/mesos-rxjava-recordio/src/main/java/org/apache/mesos/rx/java/recordio/RecordIOOperator.java
@@ -120,13 +120,13 @@ public final class RecordIOOperator implements Operator<byte[], ByteBuf> {
          * will be called and the method will terminate without attempting to do any
          * sort of recovery.
          *
-         * @param t    The {@link ByteBuf} to process
+         * @param buf    The {@link ByteBuf} to process
          */
         @Override
-        public void onNext(final ByteBuf t) {
+        public void onNext(final ByteBuf buf) {
             try {
-                final ByteBufInputStream in = new ByteBufInputStream(t);
-                while (t.readableBytes() > 0) {
+                final ByteBufInputStream in = new ByteBufInputStream(buf);
+                while (buf.readableBytes() > 0) {
                     // New message
                     if (remainingBytesForMessage == 0) {
 
@@ -161,7 +161,7 @@ public final class RecordIOOperator implements Operator<byte[], ByteBuf> {
                     }
 
                     // read bytes until we either reach the end of the ByteBuf or the message is fully read.
-                    final int readableBytes = t.readableBytes();
+                    final int readableBytes = buf.readableBytes();
                     if (readableBytes > 0) {
                         final int writeStart = messageBytes.length - remainingBytesForMessage;
                         final int numBytesToCopy = Math.min(readableBytes, remainingBytesForMessage);

--- a/mesos-rxjava-recordio/src/test/java/org/apache/mesos/rx/java/recordio/RecordIOOperatorTest.java
+++ b/mesos-rxjava-recordio/src/test/java/org/apache/mesos/rx/java/recordio/RecordIOOperatorTest.java
@@ -155,9 +155,6 @@ public class RecordIOOperatorTest {
         child.assertNoErrors();
         child.assertNotCompleted();
         child.assertNoTerminalEvent();
-        assertThat(subscriber.messageSizeBytesBuffer).isEmpty();
-        assertThat(subscriber.messageBytes).isNull();
-        assertThat(subscriber.remainingBytesForMessage).isEqualTo(0);
 
         return RecordIOUtils.listMap(child.getOnNextEvents(), (bs) -> {
             try {


### PR DESCRIPTION
This is a tentative change. I have a few more ideas to simplify the remaining large chunk of code, but I'd like to know if I'm going in the right direction.

I've created a `MessageStream` class that makes it slightly easier to parse the RecordIO messages from the incoming stream of `ByteBuf`s from Netty. It hides the individual `ByteBuf`s behind an `InputStream`, so that the parsing code does not need to worry about their methods or switching from one `ByteBuf` to the next.

I've also made some minor code simplifications which I hope improve readability. And there is now a length limit for the "message size" field, to prevent us from using an unbounded amount of memory when parsing it.