### PR TITLE
Sink operation

### DIFF
--- a/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/MesosClientErrorContext.java
+++ b/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/MesosClientErrorContext.java
@@ -1,0 +1,61 @@
+package org.apache.mesos.rx.java;
+
+import com.google.common.base.Joiner;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public final class MesosClientErrorContext {
+    private static final Joiner MAP_JOINER = Joiner.on(",").skipNulls();
+
+    private final int statusCode;
+    private final String message;
+    private final List<Map.Entry<String, String>> headers;
+
+    public MesosClientErrorContext(final int statusCode, final String message, final List<Map.Entry<String, String>> headers) {
+        this.statusCode = statusCode;
+        this.message = message;
+        this.headers = headers;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public List<Map.Entry<String, String>> getHeaders() {
+        return headers;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        final MesosClientErrorContext that = (MesosClientErrorContext) o;
+        return statusCode == that.statusCode &&
+            Objects.equals(message, that.message) &&
+            Objects.equals(headers, that.headers);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(statusCode, message, headers);
+    }
+
+    @Override
+    public String toString() {
+        return "MesosClientErrorContext{" +
+            "statusCode=" + statusCode +
+            ", message='" + message + '\'' +
+            ", headers=" + MAP_JOINER.join(headers) +
+            '}';
+    }
+}

--- a/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/MesosClientException.java
+++ b/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/MesosClientException.java
@@ -1,0 +1,24 @@
+package org.apache.mesos.rx.java;
+
+public final class MesosClientException extends RuntimeException {
+    private final Object originalCall;
+    private final MesosClientErrorContext context;
+
+    public MesosClientException(final Object originalCall, final MesosClientErrorContext context) {
+        super(
+            "Error while trying to send request."
+                + " Status: " + context.getStatusCode()
+                + " Message: '" + context.getMessage() + "'"
+        );
+        this.originalCall = originalCall;
+        this.context = context;
+    }
+
+    public Object getOriginalCall() {
+        return originalCall;
+    }
+
+    public MesosClientErrorContext getContext() {
+        return context;
+    }
+}

--- a/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/MesosServerException.java
+++ b/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/MesosServerException.java
@@ -1,0 +1,19 @@
+package org.apache.mesos.rx.java;
+
+public final class MesosServerException extends RuntimeException {
+    private final Object originalCall;
+    private final MesosClientErrorContext context;
+
+    public MesosServerException(final Object originalCall, final MesosClientErrorContext context) {
+        this.originalCall = originalCall;
+        this.context = context;
+    }
+
+    public Object getOriginalCall() {
+        return originalCall;
+    }
+
+    public MesosClientErrorContext getContext() {
+        return context;
+    }
+}

--- a/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/ProtoUtils.java
+++ b/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/ProtoUtils.java
@@ -55,7 +55,7 @@ public final class ProtoUtils {
 
     @NotNull
     public static String protoToString(@NotNull final Message message) {
-        return PROTO_TO_STRING.matcher(message.toString()).replaceAll(" ").trim();
+        return "{ " + PROTO_TO_STRING.matcher(message.toString()).replaceAll(" ").trim() + " }";
     }
 
     @NotNull

--- a/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/Rx.java
+++ b/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/Rx.java
@@ -1,0 +1,20 @@
+package org.apache.mesos.rx.java;
+
+import org.jetbrains.annotations.NotNull;
+import rx.Scheduler;
+import rx.schedulers.Schedulers;
+
+public final class Rx {
+
+    private Rx() {}
+
+    @NotNull
+    public static Scheduler compute() {
+        return Schedulers.computation();
+    }
+
+    @NotNull
+    public static Scheduler io() {
+        return Schedulers.io();
+    }
+}

--- a/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/SinkOperation.java
+++ b/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/SinkOperation.java
@@ -1,0 +1,67 @@
+package org.apache.mesos.rx.java;
+
+import org.jetbrains.annotations.NotNull;
+import rx.functions.Action0;
+import rx.functions.Action1;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * A simple object that represents a {@link org.apache.mesos.v1.scheduler.Protos.Call} that is to be sent
+ * to Mesos.  The current implementation of Mesos is such that any call to its HTTP API with a
+ * {@link org.apache.mesos.v1.scheduler.Protos.Call} that isn't a
+ * {@link org.apache.mesos.v1.scheduler.Protos.Call.Type#SUBSCRIBE} will result in a semi-blocking response.
+ * <p/>
+ * This means things like request validation (including body deserialization and field validation) are
+ * performed synchronously during the request. Due to this behavior, this class exists to inform the
+ * user of the success or failure of requests sent to the master.
+ * <p/>
+ * It should be noted that this object doesn't represent the means of detecting and handling connection errors
+ * with Mesos as the intent is that it will be communicated to the whole event stream rather than an
+ * individual {@link org.apache.mesos.v1.scheduler.Protos.Call}.
+ * <p/>
+ * <i>NOTE</i>
+ * The semantics of which thread a callback will be invoked on are undefined and should not be relied upon.
+ * This means that all standard thread safety/guards should be in place for state changes that take place
+ * inside the callbacks.
+ *
+ * @see SinkOperations#create
+ */
+public final class SinkOperation<T> {
+    @NotNull
+    private final T thingToSink;
+    @NotNull
+    private final Action1<Throwable> onError;
+    @NotNull
+    private final Action0 onCompleted;
+
+    /**
+     * This constructor is considered an internal API and should not be used directly, instead use one of the
+     * factory methods defined in {@link SinkOperations}.
+     * @param thingToSink    The {@link org.apache.mesos.v1.scheduler.Protos.Call} to send to Mesos
+     * @param onCompleted    The callback invoked when HTTP 202 is returned by Mesos
+     * @param onError        The callback invoked for an HTTP 400 or 500 status code returned by Mesos
+     */
+    SinkOperation(
+        @NotNull final T thingToSink,
+        @NotNull final Action0 onCompleted,
+        @NotNull final Action1<Throwable> onError
+    ) {
+        this.thingToSink = checkNotNull(thingToSink, "argument thingToSink can not be null");
+        this.onCompleted = checkNotNull(onCompleted, "argument onCompleted can not be null");
+        this.onError = checkNotNull(onError, "argument onError can not be null");
+    }
+
+    public void onCompleted() {
+        onCompleted.call();
+    }
+
+    public void onError(final Throwable e) {
+        onError.call(e);
+    }
+
+    @NotNull
+    public T getThingToSink() {
+        return thingToSink;
+    }
+}

--- a/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/SinkOperations.java
+++ b/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/SinkOperations.java
@@ -1,0 +1,80 @@
+package org.apache.mesos.rx.java;
+
+import org.apache.mesos.v1.scheduler.Protos;
+import org.jetbrains.annotations.NotNull;
+import rx.functions.Action0;
+import rx.functions.Action1;
+
+public final class SinkOperations {
+    private SinkOperations() {}
+
+    @NotNull
+    public static SinkOperation create(
+        @NotNull final Protos.Call call,
+        @NotNull final Action0 onCompleted,
+        @NotNull final Action1<Throwable> onError
+    ) {
+        return new SinkOperation(call, onCompleted, onError);
+    }
+
+    @NotNull
+    public static SinkOperation create(
+        @NotNull final Protos.Call call,
+        @NotNull final Action0 onCompleted
+    ) {
+        return new SinkOperation(call, onCompleted, (t) -> {});
+    }
+
+    @NotNull
+    public static SinkOperation create(
+        @NotNull final Protos.Call call,
+        @NotNull final Action1<Throwable> onError
+    ) {
+        return new SinkOperation(call, () -> {}, onError);
+    }
+
+    @NotNull
+    public static SinkOperation create(
+        @NotNull final Protos.Call call
+    ) {
+        return new SinkOperation(
+            call,
+            () -> {},
+            (t) -> {}
+        );
+    }
+
+    @NotNull
+    public static SinkOperation sink(
+        @NotNull final Protos.Call call,
+        @NotNull final Action0 onCompleted,
+        @NotNull final Action1<Throwable> onError
+    ) {
+        return create(call, onCompleted, onError);
+    }
+
+    @NotNull
+    public static SinkOperation sink(
+        @NotNull final Protos.Call call,
+        @NotNull final Action0 onCompleted
+    ) {
+        return create(call, onCompleted);
+    }
+
+    @NotNull
+    public static SinkOperation sink(
+        @NotNull final Protos.Call call,
+        @NotNull final Action1<Throwable> onError
+    ) {
+        return create(call, onError);
+    }
+
+    @NotNull
+    public static SinkOperation sink(
+        @NotNull final Protos.Call call
+    ) {
+        return create(call);
+    }
+
+
+}

--- a/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/SinkSubscriber.java
+++ b/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/SinkSubscriber.java
@@ -1,0 +1,90 @@
+package org.apache.mesos.rx.java;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.CharsetUtil;
+import io.reactivex.netty.protocol.http.client.HttpClient;
+import io.reactivex.netty.protocol.http.client.HttpClientRequest;
+import io.reactivex.netty.protocol.http.client.HttpResponseHeaders;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import rx.Observable;
+import rx.Subscriber;
+import rx.exceptions.Exceptions;
+import rx.functions.Func1;
+
+import java.util.List;
+import java.util.Map;
+
+final class SinkSubscriber<Send> extends Subscriber<SinkOperation<Send>> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SinkSubscriber.class);
+
+    @NotNull
+    private final HttpClient<ByteBuf, ByteBuf> httpClient;
+    @NotNull
+    private final Func1<Send, Observable<HttpClientRequest<ByteBuf>>> createPost;
+
+    SinkSubscriber(
+        @NotNull final HttpClient<ByteBuf, ByteBuf> httpClient,
+        @NotNull final Func1<Send, Observable<HttpClientRequest<ByteBuf>>> createPost
+    ) {
+        LOGGER.debug("SinkSubscriber(httpClient : {}, createPost : {})", httpClient, createPost);
+        this.httpClient = httpClient;
+        this.createPost = createPost;
+    }
+
+    @Override
+    public void onNext(final SinkOperation<Send> op) {
+        try {
+            final Send toSink = op.getThingToSink();
+            createPost.call(toSink)
+                .flatMap(httpClient::submit)
+                .subscribeOn(Rx.compute())
+                .subscribe(resp -> {
+                    final HttpResponseStatus status = resp.getStatus();
+                    final int code = status.code();
+
+                    if (code == 202) {
+                        /* This is success */
+                        op.onCompleted();  // TODO: Try and make sure this is actually executed on the compute thread
+                    } else {
+                        resp.getContent()
+                            .map(buf -> {
+                                final String errorMessage = buf.toString(CharsetUtil.UTF_8);
+                                final HttpResponseHeaders headers = resp.getHeaders();
+                                final List<Map.Entry<String, String>> entries = headers.entries();
+                                return new MesosClientErrorContext(code, errorMessage, entries);
+                            })
+                            // TODO: Schedule on computation()
+                            .observeOn(Rx.compute())
+                            .forEach(context -> {
+                                if (400 <= code && code < 500) {
+                                    // client error
+                                    op.onError(new MesosClientException(toSink, context));
+                                } else if (500 <= code && code < 600) {
+                                    // client error
+                                    op.onError(new MesosServerException(toSink, context));
+                                } else {
+                                    // Unknown error
+                                    LOGGER.warn("Unhandled error: context = {}", context);
+                                }
+                            });
+                    }
+                });
+        } catch (Throwable e) {
+            Exceptions.throwIfFatal(e);
+            op.onError(e);
+        }
+    }
+
+    @Override
+    public void onError(final Throwable e) {
+        LOGGER.debug("onError(e : {})", e.getMessage());
+    }
+
+    @Override
+    public void onCompleted() {
+        LOGGER.debug("onCompleted()");
+    }
+}

--- a/mesos-rxjava-example/mesos-rxjava-example-framework/src/main/java/org/apache/mesos/rx/java/example/framework/sleepy/State.java
+++ b/mesos-rxjava-example/mesos-rxjava-example-framework/src/main/java/org/apache/mesos/rx/java/example/framework/sleepy/State.java
@@ -1,0 +1,36 @@
+package org.apache.mesos.rx.java.example.framework.sleepy;
+
+import org.apache.mesos.v1.Protos;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+import static com.google.common.collect.Maps.newConcurrentMap;
+
+final class State {
+    private static final Logger LOGGER = LoggerFactory.getLogger(State.class);
+
+    private Protos.FrameworkID fwId;
+
+    @NotNull
+    private final Map<Protos.TaskID, Protos.TaskState> taskStates;
+
+    public State() {
+        this.taskStates = newConcurrentMap();
+    }
+
+    public synchronized Protos.FrameworkID getFwId() {
+        return fwId;
+    }
+
+    public synchronized void setFwId(final Protos.FrameworkID fwId) {
+        this.fwId = fwId;
+    }
+
+    public void put(final Protos.TaskID key, final Protos.TaskState value) {
+        LOGGER.debug("put(key : {}, value : {})", key.getValue(), value);
+        taskStates.put(key, value);
+    }
+}

--- a/mesos-rxjava-example/mesos-rxjava-example-framework/src/main/resources/logback.xml
+++ b/mesos-rxjava-example/mesos-rxjava-example-framework/src/main/resources/logback.xml
@@ -26,6 +26,7 @@
     </appender>
 
     <logger name="org.apache.mesos.rx.java" level="info"/>
+    <logger name="org.apache.mesos.rx.java.example.framework.sleepy.State" level="debug"/>
     <logger name="io.netty.handler.logging.LoggingHandler" level="info"/>
 
     <root level="debug">


### PR DESCRIPTION
Refactor MesosSchedulerClient so that sink takes a SinkOperation

The new `SinkOperation` encapsulates the call to be sent to the server, with a potential `onComplete` and `onError` handlers.

If `onError` is to be called an exception capturing the context of the request (MesosClientErrorContext) will be one of the fields of the exception. There are different exceptions representing the different categories of errors that can be encountered when communicating with the server. `MesosClientException` represents HTTP 400 class errors. `MesosServerException` represents HTTP 500 class errors.

When a stream of Observable<SinkOperation> is passed to `sink` it is now subscribed to with a custom subscriber.  This pattern makes much more sense from and Rx and Event stream stand point as a Subscriber represents the thing that consumes the events from the Observable.