### PR TITLE
Refactor MesosSchedulerClient API for improve lifecycle management.

### DIFF
--- a/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/AwaitableSubscription.java
+++ b/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/AwaitableSubscription.java
@@ -1,0 +1,23 @@
+package org.apache.mesos.rx.java;
+
+import rx.Subscriber;
+import rx.Subscription;
+
+/**
+ * A sub-interface of {@link Subscription} that provides the definition of a subscription that can be
+ * awaited.
+ * <p/>
+ * This is useful for an application that wants to start up an event stream and block its main thread
+ * until the event stream has completed.
+ */
+public interface AwaitableSubscription extends Subscription {
+
+    /**
+     * Blocks the current thread until the underlying {@link rx.Observable} ends.
+     * If the {@code rx.Observable} ends due to  {@link Subscriber#onError(Throwable) onError} the {@code Throwable}
+     * delivered to {@code onError} will be rethrown. If the {@code rx.Observable} ends by
+     * {@link Subscriber#onCompleted() onCompleted} the method will complete cleanly.
+     */
+    void await() throws Throwable;
+
+}

--- a/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/MesosSchedulerClientBuilder.java
+++ b/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/MesosSchedulerClientBuilder.java
@@ -1,0 +1,164 @@
+package org.apache.mesos.rx.java;
+
+import org.jetbrains.annotations.NotNull;
+import rx.Observable;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.function.Function;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Builder used to create a {@link MesosSchedulerClient}.
+ * <p/>
+ * PLEASE NOTE: All methods in this class function as "set" rather than "copy with new value"
+ * @param <Send>       The type of objects that will be sent to Mesos
+ * @param <Receive>    The type of objects are expected from Mesos
+ */
+public final class MesosSchedulerClientBuilder<Send, Receive> {
+
+    private URI mesosUri;
+    private Function<Class<?>, UserAgentEntry> applicationUserAgentEntry;
+    private MessageCodec<Send> sendCodec;
+    private MessageCodec<Receive> receiveCodec;
+    private Send subscribe;
+    private Function<Observable<Receive>, Observable<Optional<SinkOperation<Send>>>> streamProcessor;
+
+    private MesosSchedulerClientBuilder() {}
+
+    /**
+     * Create a new instance of {@link MesosSchedulerClientBuilder}
+     * @param <Send>       The type of objects that will be sent to Mesos
+     * @param <Receive>    The type of objects are expected from Mesos
+     * @return A new instance of {@link MesosSchedulerClientBuilder}
+     */
+    @NotNull
+    public static <Send, Receive> MesosSchedulerClientBuilder<Send, Receive> newBuilder() {
+        return new MesosSchedulerClientBuilder<>();
+    }
+
+    /**
+     * The {@link URI} that should be used to connect to Mesos. The following segments of the URI are used:
+     * <ul>
+     *     <li>hostname</li>
+     *     <li>port</li>
+     *     <li>username</li>
+     *     <li>password</li>
+     *     <li>path</li>
+     * </ul>
+     * @param mesosUri    Fully qualified URI to use to connect to mesos.
+     * @return this builder (allowing for further chained calls)
+     */
+    @NotNull
+    public MesosSchedulerClientBuilder<Send, Receive> mesosUri(
+        @NotNull final URI mesosUri
+    ) {
+        this.mesosUri = mesosUri;
+        return this;
+    }
+
+    /**
+     * Sets the function used to create a {@link UserAgentEntry} to be included the {@code User-Agent} header
+     * sent to Mesos for all requests.
+     * @param applicationUserAgentEntry    Function to provide the {@link UserAgentEntry}
+     * @return this builder (allowing for further chained calls)
+     */
+    @NotNull
+    public MesosSchedulerClientBuilder<Send, Receive> applicationUserAgentEntry(
+        @NotNull final Function<Class<?>, UserAgentEntry> applicationUserAgentEntry
+    ) {
+        this.applicationUserAgentEntry = applicationUserAgentEntry;
+        return this;
+    }
+
+    /**
+     * Allows configuration of the codec used for the {@code Send} type.
+     * @param sendCodec    {@link MessageCodec} for {@code Send} type
+     * @return this builder (allowing for further chained calls)
+     */
+    @NotNull
+    public MesosSchedulerClientBuilder<Send, Receive> sendCodec(
+        @NotNull final MessageCodec<Send> sendCodec
+    ) {
+        this.sendCodec = sendCodec;
+        return this;
+    }
+
+    /**
+     * Allows configuration of the codec used for the {@code Receive} type.
+     * @param receiveCodec    {@link MessageCodec} for {@code Receive} type
+     * @return this builder (allowing for further chained calls)
+     */
+    @NotNull
+    public MesosSchedulerClientBuilder<Send, Receive> receiveCodec(
+        @NotNull final MessageCodec<Receive> receiveCodec
+    ) {
+        this.receiveCodec = receiveCodec;
+        return this;
+    }
+
+    /**
+     * @param subscribe     The {@link org.apache.mesos.v1.scheduler.Protos.Call.Type#SUBSCRIBE}
+     *                      {@link org.apache.mesos.v1.scheduler.Protos.Call} to be sent to Mesos
+     *                      when opening the event stream.
+     * @return this builder (allowing for further chained calls)
+     */
+    @NotNull
+    public MesosSchedulerClientBuilder<Send, Receive> subscribe(
+        @NotNull final Send subscribe
+    ) {
+        this.subscribe = subscribe;
+        return this;
+    }
+
+    /**
+     * This method provides the means for a user to define how the event stream will be processed.
+     * <p/>
+     * The function passed to this method will function as the actual event processing code for the user.
+     * <p/>
+     * The stream the users will source from is an {@link Observable} of {@code Receive}s. With this stream
+     * source a number of functions can be applied to transform/interact/evaluate the stream.
+     * <p/>
+     * The output of this function represents the users reaction to each event represented as an
+     * {@code Observable<Optional<SinkOperation<Send>>>}. If {@link Optional#isPresent()} the specified
+     * {@link SinkOperation} will be processed.
+     * <p/>
+     * For example, if you wanted to log all tasks that result in error:
+     * <pre><code>
+     * events -> {
+     *     final Observable&lt;Optional&lt;SinkOperation&lt;Call>>> errorLogger = events
+     *         .filter(event -> event.getType() == Event.Type.UPDATE && event.getUpdate().getStatus().getState() == TaskState.TASK_ERROR)
+     *         .doOnNext(e -> LOGGER.warn("Task Error: {}", ProtoUtils.protoToString(e)))
+     *         .map(e -> Optional.empty());
+     * }
+     * </code></pre>
+     * @param streamProcessing    The function that will be woven between the event spout and the call sink
+     * @return this builder (allowing for further chained calls)
+     */
+    @NotNull
+    public MesosSchedulerClientBuilder<Send, Receive> processStream(
+        @NotNull final Function<Observable<Receive>, Observable<Optional<SinkOperation<Send>>>> streamProcessing
+    ) {
+        this.streamProcessor = streamProcessing;
+        return this;
+    }
+
+    /**
+     * Builds the instance of {@link MesosSchedulerClient} that has been configured by this builder.
+     * All items are expected to have non-null values, if any item is null an exception will be thrown.
+     * @return The configured {@link MesosSchedulerClient}
+     */
+    @NotNull
+    public final MesosSchedulerClient<Send, Receive> build() {
+        return new MesosSchedulerClient<>(
+            checkNotNull(mesosUri),
+            checkNotNull(applicationUserAgentEntry),
+            checkNotNull(sendCodec),
+            checkNotNull(receiveCodec),
+            checkNotNull(subscribe),
+            checkNotNull(streamProcessor)
+        );
+    }
+
+}

--- a/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/MesosSchedulerClientBuilders.java
+++ b/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/MesosSchedulerClientBuilders.java
@@ -1,0 +1,22 @@
+package org.apache.mesos.rx.java;
+
+import org.apache.mesos.v1.scheduler.Protos;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * A collection of methods that have some pre-defined {@link MesosSchedulerClientBuilder} configurations.
+ */
+public final class MesosSchedulerClientBuilders {
+    /**
+     * @return  An initial {@link MesosSchedulerClientBuilder} that will use protobuf
+     *          for the {@link org.apache.mesos.v1.scheduler.Protos.Call} and
+     *          {@link org.apache.mesos.v1.scheduler.Protos.Event} messages.
+     */
+    @NotNull
+    public static MesosSchedulerClientBuilder<Protos.Call, Protos.Event> usingProtos() {
+        return MesosSchedulerClientBuilder.<Protos.Call, Protos.Event>newBuilder()
+            .sendCodec(MessageCodecs.PROTOS_CALL)
+            .receiveCodec(MessageCodecs.PROTOS_EVENT)
+            ;
+    }
+}

--- a/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/MessageCodecs.java
+++ b/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/MessageCodecs.java
@@ -1,6 +1,9 @@
 package org.apache.mesos.rx.java;
 
 import org.apache.mesos.v1.scheduler.Protos;
+import org.jetbrains.annotations.NotNull;
+
+import java.nio.charset.StandardCharsets;
 
 /**
  * Utilities for working with {@link MessageCodec} instances.
@@ -13,6 +16,39 @@ public final class MessageCodecs {
     /** A {@link org.apache.mesos.rx.java.MessageCodec} for {@link org.apache.mesos.v1.scheduler.Protos.Event}. */
     public static final MessageCodec<Protos.Event> PROTOS_EVENT = new ProtoCodec<>(Protos.Event::parseFrom);
 
+    @NotNull
+    public static final MessageCodec<String> UTF8_STRING = new StringMessageCodec();
+
     private MessageCodecs() {}
+
+    /**
+     * UTF_8 String codec
+     * @see StandardCharsets#UTF_8
+     */
+    private static final class StringMessageCodec implements MessageCodec<String> {
+        @NotNull
+        @Override
+        public byte[] encode(@NotNull final String message) {
+            return message.getBytes(StandardCharsets.UTF_8);
+        }
+
+        @NotNull
+        @Override
+        public String decode(@NotNull final byte[] bytes) {
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
+
+        @NotNull
+        @Override
+        public String mediaType() {
+            return "text/plain";
+        }
+
+        @NotNull
+        @Override
+        public String show(@NotNull final String message) {
+            return message;
+        }
+    }
 
 }

--- a/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/SinkSubscriber.java
+++ b/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/SinkSubscriber.java
@@ -29,7 +29,6 @@ final class SinkSubscriber<Send> extends Subscriber<SinkOperation<Send>> {
         @NotNull final HttpClient<ByteBuf, ByteBuf> httpClient,
         @NotNull final Func1<Send, Observable<HttpClientRequest<ByteBuf>>> createPost
     ) {
-        LOGGER.debug("SinkSubscriber(httpClient : {}, createPost : {})", httpClient, createPost);
         this.httpClient = httpClient;
         this.createPost = createPost;
     }
@@ -80,11 +79,10 @@ final class SinkSubscriber<Send> extends Subscriber<SinkOperation<Send>> {
 
     @Override
     public void onError(final Throwable e) {
-        LOGGER.debug("onError(e : {})", e.getMessage());
+        Exceptions.throwIfFatal(e);
     }
 
     @Override
     public void onCompleted() {
-        LOGGER.debug("onCompleted()");
     }
 }

--- a/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/package-info.java
+++ b/mesos-rxjava-core/src/main/java/org/apache/mesos/rx/java/package-info.java
@@ -1,0 +1,67 @@
+/*
+ *    Copyright (C) 2015 Apache Software Foundation (ASF)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+/**
+ * This package provides the code necessary to create and interact with {@link rx.Observable} events
+ * coming from Apache Mesos.
+ *
+ * The following is a full Apache Mesos Framework that declines all resource offers:
+ * <pre><code>
+ * import static org.apache.mesos.v1.Protos.*;
+ * import static org.apache.mesos.v1.scheduler.Protos.*;
+ *
+ * final Protos.FrameworkID fwId = FrameworkID.newBuilder().setValue(UUID.randomUUID().toString()).build();
+ * org.apache.mesos.rx.java.MesosSchedulerClientBuilders.usingProtos()
+ *     .mesosUri(URI.create("http://localhost:5050/api/v1/scheduler"))
+ *     .applicationUserAgentEntry(UserAgentEntries.literal("decline-framework", "0.1.0-SNAPSHOT"))
+ *     .subscribe(
+ *         Call.newBuilder()
+ *             .setFrameworkId(fwId)
+ *             .setType(Call.Type.SUBSCRIBE)
+ *             .setSubscribe(
+ *                 Call.Subscribe.newBuilder()
+ *                     .setFrameworkInfo(
+ *                         Protos.FrameworkInfo.newBuilder()
+ *                             .setId(fwId)
+ *                             .setUser("root")
+ *                             .setName("decline-framework")
+ *                             .setFailoverTimeout(0)
+ *                     )
+ *             )
+ *             .build()
+ *     )
+ *     .processStream(es ->
+ *         es.filter(event -> event.getType() == Event.Type.OFFERS)
+ *         .flatMap(event -> Observable.from(event.getOffers().getOffersList()))
+ *         .map(offer ->
+ *             Call.newBuilder()
+ *                 .setFrameworkId(fwId)
+ *                 .setType(Call.Type.DECLINE)
+ *                 .setDecline(
+ *                     Call.Decline.newBuilder()
+ *                         .addOfferIds(offer.getId())
+ *                 )
+ *                 .build()
+ *         )
+ *         .map(SinkOperations::create)
+ *         .map(Optional::of)
+ *     )
+ *     .build()
+ *     .openStream()
+ *     .await();
+ * </code></pre>
+ */
+package org.apache.mesos.rx.java;

--- a/mesos-rxjava-core/src/test/java/org/apache/mesos/rx/java/SubscriberDecoratorTest.java
+++ b/mesos-rxjava-core/src/test/java/org/apache/mesos/rx/java/SubscriberDecoratorTest.java
@@ -1,0 +1,163 @@
+/*
+ *    Copyright (C) 2015 Apache Software Foundation (ASF)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.apache.mesos.rx.java;
+
+import org.junit.Test;
+import rx.Observable;
+import rx.observers.Subscribers;
+import rx.observers.TestSubscriber;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class SubscriberDecoratorTest {
+
+
+    @Test
+    public void worksForCompleted() throws Exception {
+        final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
+        final MesosSchedulerClient.SubscriberDecorator<String> decorator = new MesosSchedulerClient.SubscriberDecorator<>(testSubscriber);
+        Observable.just("something")
+            .subscribe(decorator);
+
+        testSubscriber.assertCompleted();
+        testSubscriber.assertNoErrors();
+        testSubscriber.assertValueCount(1);
+        testSubscriber.assertValue("something");
+
+        assertThat(decorator.call()).isEqualTo(Optional.empty());
+    }
+
+    @Test
+    public void worksForError() throws Exception {
+        final ExecutorService service = Executors.newSingleThreadExecutor();
+        final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
+        final MesosSchedulerClient.SubscriberDecorator<String> decorator = new MesosSchedulerClient.SubscriberDecorator<>(testSubscriber);
+        Observable.<String>from(service.submit(() -> {throw new RuntimeException("kaboom");}))
+            .subscribe(decorator);
+
+        testSubscriber.assertNoValues();
+        testSubscriber.assertError(ExecutionException.class);
+
+        final Optional<Throwable> e = decorator.call();
+        assertThat(e.isPresent()).isTrue();
+        final Throwable t = e.get();
+        assertThat(t).isInstanceOf(ExecutionException.class);
+        assertThat(t.getCause()).isInstanceOf(RuntimeException.class);
+        assertThat(t.getCause().getMessage()).isEqualTo("kaboom");
+    }
+
+    @Test
+    public void exceptionThrowByOnErrorIsReturned() throws Exception {
+        final MesosSchedulerClient.SubscriberDecorator<String> decorator = new MesosSchedulerClient.SubscriberDecorator<>(
+            Subscribers.<String>create(
+                s -> {throw new RuntimeException("Supposed to break");},
+                (t) -> {throw new RuntimeException("wrapped", t);}
+            )
+        );
+        Observable.just("doesn't matter")
+            .subscribe(decorator);
+
+        final Optional<Throwable> e = decorator.call();
+        assertThat(e.isPresent()).isTrue();
+        final Throwable t = e.get();
+        assertThat(t).isInstanceOf(RuntimeException.class);
+        assertThat(t.getMessage()).isEqualTo("wrapped");
+        assertThat(t.getCause().getMessage()).isEqualTo("Supposed to break");
+    }
+
+    @Test
+    public void exceptionThrowByOnCompletedIsReturned() throws Exception {
+        final MesosSchedulerClient.SubscriberDecorator<String> decorator = new MesosSchedulerClient.SubscriberDecorator<>(
+            Subscribers.<String>create(
+                s -> {},
+                (t) -> {throw new RuntimeException("wrapped", t);},
+                () -> {throw new RuntimeException("wrapped2");}
+            )
+        );
+        Observable.just("doesn't matter")
+            .subscribe(decorator);
+
+        final Optional<Throwable> e = decorator.call();
+        assertThat(e.isPresent()).isTrue();
+        final Throwable t = e.get();
+        assertThat(t).isInstanceOf(RuntimeException.class);
+        assertThat(t.getMessage()).isEqualTo("wrapped2");
+    }
+
+    @Test(expected = StackOverflowError.class)
+    public void fatalExceptionIsThrown() throws Exception {
+        final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
+        final MesosSchedulerClient.SubscriberDecorator<String> decorator = new MesosSchedulerClient.SubscriberDecorator<>(testSubscriber);
+        Observable.just("doesn't matter")
+            .map((s) -> {
+                //noinspection ConstantIfStatement,ConstantConditions  -- This is here to trick the compiler to think this function returns a string
+                if (true) {
+                    throw new StackOverflowError("stack overflow");
+                }
+                return s;
+            })
+            .subscribe(decorator);
+
+        testSubscriber.assertNoValues();
+    }
+
+    @Test
+    public void onlyOneValueWillBeHeld_completed() throws Exception {
+        final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
+        final MesosSchedulerClient.SubscriberDecorator<String> decorator = new MesosSchedulerClient.SubscriberDecorator<>(testSubscriber);
+
+        decorator.onCompleted();
+        decorator.onCompleted();
+
+        final Optional<Throwable> call = decorator.call();
+        assertThat(call.isPresent()).isFalse();
+    }
+
+    @Test
+    public void receiveFirstValue_error() throws Exception {
+        final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
+        final MesosSchedulerClient.SubscriberDecorator<String> decorator = new MesosSchedulerClient.SubscriberDecorator<>(testSubscriber);
+
+        decorator.onError(new RuntimeException("this one"));
+        decorator.onError(new RuntimeException("not this one"));
+
+        final Optional<Throwable> e = decorator.call();
+        assertThat(e.isPresent()).isTrue();
+        final Throwable t = e.get();
+        assertThat(t).isInstanceOf(RuntimeException.class);
+        assertThat(t.getMessage()).isEqualTo("this one");
+    }
+
+    @Test
+    public void onlyOneValueWillBeHeld_completedThenError() throws Exception {
+        final TestSubscriber<String> testSubscriber = new TestSubscriber<>();
+        final MesosSchedulerClient.SubscriberDecorator<String> decorator = new MesosSchedulerClient.SubscriberDecorator<>(testSubscriber);
+
+        decorator.onCompleted();
+        decorator.onError(new RuntimeException("really doesn't matter"));
+
+        final Optional<Throwable> call = decorator.call();
+        assertThat(call.isPresent()).isFalse();
+    }
+
+}

--- a/mesos-rxjava-example/mesos-rxjava-example-framework/pom.xml
+++ b/mesos-rxjava-example/mesos-rxjava-example-framework/pom.xml
@@ -28,6 +28,10 @@
             <artifactId>mesos-rxjava-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.mesos.rx.java</groupId>
+            <artifactId>mesos-rxjava-test</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.mesos</groupId>
             <artifactId>mesos</artifactId>
         </dependency>

--- a/mesos-rxjava-example/mesos-rxjava-example-framework/src/main/resources/logback.xml
+++ b/mesos-rxjava-example/mesos-rxjava-example-framework/src/main/resources/logback.xml
@@ -25,11 +25,11 @@
         </encoder>
     </appender>
 
-    <logger name="org.apache.mesos.rx.java" level="info"/>
+    <logger name="org.apache.mesos.rx.java" level="debug"/>
     <!--<logger name="org.apache.mesos.rx.java.example.framework.sleepy.State" level="debug"/>-->
     <logger name="io.netty.handler.logging.LoggingHandler" level="info"/>
 
-    <root level="debug">
+    <root level="info">
         <appender-ref ref="STDOUT"/>
     </root>
 

--- a/mesos-rxjava-test/src/main/java/org/apache/mesos/rx/java/test/TcpSocketProxy.java
+++ b/mesos-rxjava-test/src/main/java/org/apache/mesos/rx/java/test/TcpSocketProxy.java
@@ -1,0 +1,187 @@
+package org.apache.mesos.rx.java.test;
+
+import com.google.common.collect.Lists;
+import com.google.common.io.ByteStreams;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.SocketException;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * A utility class that can used to create a proxy between mesos and your client,
+ * and then close the connection to verify behavior.
+ */
+public final class TcpSocketProxy implements Closeable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(TcpSocketProxy.class);
+
+    @NotNull
+    private final AtomicInteger threadCounter = new AtomicInteger(1);
+    @NotNull
+    private final ExecutorService service = Executors.newCachedThreadPool(
+        r -> new Thread(r, "TcpSocketProxy-" + threadCounter.getAndIncrement())
+    );
+
+    @NotNull
+    private final ScheduledExecutorService murderService = Executors.newSingleThreadScheduledExecutor(
+        r -> new Thread(r, "TcpSocketProxy-murderer")
+    );
+
+    @NotNull
+    private final InetSocketAddress listen;
+    @NotNull
+    private final InetSocketAddress dest;
+
+    @NotNull
+    private final List<Socket> sockets;
+
+    @NotNull
+    private final AtomicReference<ServerSocket> socketRef;
+
+    @NotNull
+    private final List<Future<?>> futures;
+    @NotNull
+    private final AtomicBoolean shutdown;
+
+    @Nullable
+    private ScheduledFuture<?> murderer;
+
+    public TcpSocketProxy(@NotNull final InetSocketAddress listen, @NotNull final InetSocketAddress destination) {
+        this.listen = listen;
+        this.dest = destination;
+
+        sockets = Lists.newCopyOnWriteArrayList();
+        socketRef = new AtomicReference<>();
+        futures = Lists.newCopyOnWriteArrayList();
+        shutdown = new AtomicBoolean(false);
+    }
+
+    public void run() throws IOException {
+        if (shutdown.get()) {
+            throw new IllegalStateException("Can not run an already shutdown proxy");
+        }
+        final Future<?> submit = service.submit(new ProxyServer());
+
+        futures.add(submit);
+    }
+
+    public boolean isShutdown() {
+        return shutdown.get();
+    }
+
+    @Override
+    public void close() throws IOException {
+        shutdown();
+        if (!murderService.isShutdown()) {
+            murderService.shutdownNow();
+        }
+        murderer.cancel(true);
+        murderer = null;
+    }
+
+    public void shutdown() {
+        if (!service.isTerminated()) {
+            shutdownIn(0, TimeUnit.SECONDS);
+        }
+    }
+
+    public void shutdownIn(final long delay, @NotNull final TimeUnit timeUnit) {
+        this.murderer = murderService.schedule(new ServerShutdownTask(), delay, timeUnit);
+    }
+
+    private final class ProxyServer implements Runnable {
+        @Override
+        public void run() {
+            final String proxyDescription = String.format(
+                "%s:%d -> %s:%d",
+                listen.getAddress(),
+                listen.getPort(),
+                dest.getAddress(),
+                dest.getPort());
+            try {
+                LOGGER.info("Creating proxy: {}", proxyDescription);
+                final ServerSocket socket = new ServerSocket(listen.getPort());
+                socketRef.set(socket);
+                while (true) {
+                    final Socket accept = socket.accept();
+                    final InputStream in = accept.getInputStream();
+                    final OutputStream out = accept.getOutputStream();
+
+                    final Socket mesos = new Socket(dest.getAddress(), dest.getPort());
+                    final OutputStream send = mesos.getOutputStream();
+                    final InputStream ret = mesos.getInputStream();
+                    final Future<?> f1 = service.submit(() -> {
+                        try {
+                            ByteStreams.copy(in, send);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                    final Future<?> f2 = service.submit(() -> {
+                        try {
+                            ByteStreams.copy(ret, out);
+                        } catch (IOException e) {
+                            throw new RuntimeException(e);
+                        }
+                    });
+                    sockets.add(accept);
+                    sockets.add(mesos);
+                    futures.add(f1);
+                    futures.add(f2);
+                }
+            } catch (SocketException se) {
+                switch (se.getMessage()) {
+                    case "Socket closed":
+                        break;
+                    default:
+                        LOGGER.error(String.format("Error creating proxy: %s", proxyDescription), se);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    private final class ServerShutdownTask implements Runnable {
+        @Override
+        public void run() {
+            LOGGER.debug("Proxy shutdown starting...");
+            shutdown.set(true);
+            try {
+                if (!service.isShutdown()) {
+                    service.shutdown();
+                }
+                for (Future<?> f : futures) {
+                    f.cancel(true);
+                }
+                final ServerSocket serverSocket = socketRef.get();
+                if (!serverSocket.isClosed()) {
+                    serverSocket.close();
+                }
+                for (Socket socket : sockets) {
+                    try {
+                        socket.close();
+                    } catch (IOException ignored) {
+                        // if we get an exception trying to close one socket swallow it and move onto the next one
+                    }
+                }
+                LOGGER.debug("Proxy shutdown complete");
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/mesos-rxjava-test/src/main/java/org/apache/mesos/rx/java/test/TestingProtos.java
+++ b/mesos-rxjava-test/src/main/java/org/apache/mesos/rx/java/test/TestingProtos.java
@@ -20,6 +20,8 @@ import com.google.common.collect.Lists;
 import org.apache.mesos.v1.scheduler.Protos;
 import org.jetbrains.annotations.NotNull;
 
+import static org.apache.mesos.v1.Protos.*;
+
 public final class TestingProtos {
     @NotNull
     public static final Protos.Event HEARTBEAT = Protos.Event.newBuilder()
@@ -31,12 +33,17 @@ public final class TestingProtos {
     public static final Protos.Event OFFER = resourceOffer("host1", "offer", "slave", "frw1", 8d, 8192, 8192);
 
     @NotNull
+    public static final Protos.Call SUBSCRIBE = subscribe(
+        "a7cfd25c-79bd-481c-91cc-692e5db1ec3d", "unit-test-user", "unit-testing"
+    );
+
+    @NotNull
     public static Protos.Event subscribed(@NotNull final String frameworkId, final int heartbeatIntervalSeconds) {
         return Protos.Event.newBuilder()
             .setType(Protos.Event.Type.SUBSCRIBED)
             .setSubscribed(
                 Protos.Event.Subscribed.newBuilder()
-                    .setFrameworkId(org.apache.mesos.v1.Protos.FrameworkID.newBuilder()
+                    .setFrameworkId(FrameworkID.newBuilder()
                             .setValue(frameworkId)
                     )
                     .setHeartbeatIntervalSeconds(heartbeatIntervalSeconds)
@@ -59,29 +66,54 @@ public final class TestingProtos {
             .setOffers(
                 Protos.Event.Offers.newBuilder()
                 .addAllOffers(Lists.newArrayList(
-                    org.apache.mesos.v1.Protos.Offer.newBuilder()
+                    Offer.newBuilder()
                         .setHostname(hostname)
-                        .setId(org.apache.mesos.v1.Protos.OfferID.newBuilder().setValue(offerId))
-                        .setAgentId(org.apache.mesos.v1.Protos.AgentID.newBuilder().setValue(agentId))
-                        .setFrameworkId(org.apache.mesos.v1.Protos.FrameworkID.newBuilder().setValue(frameworkId))
-                        .addResources(org.apache.mesos.v1.Protos.Resource.newBuilder()
+                        .setId(OfferID.newBuilder().setValue(offerId))
+                        .setAgentId(AgentID.newBuilder().setValue(agentId))
+                        .setFrameworkId(FrameworkID.newBuilder().setValue(frameworkId))
+                        .addResources(Resource.newBuilder()
                             .setName("cpus")
                             .setRole("*")
-                            .setType(org.apache.mesos.v1.Protos.Value.Type.SCALAR)
-                            .setScalar(org.apache.mesos.v1.Protos.Value.Scalar.newBuilder().setValue(cpus)))
-                        .addResources(org.apache.mesos.v1.Protos.Resource.newBuilder()
+                            .setType(Value.Type.SCALAR)
+                            .setScalar(Value.Scalar.newBuilder().setValue(cpus)))
+                        .addResources(Resource.newBuilder()
                             .setName("mem")
                             .setRole("*")
-                            .setType(org.apache.mesos.v1.Protos.Value.Type.SCALAR)
-                            .setScalar(org.apache.mesos.v1.Protos.Value.Scalar.newBuilder().setValue(mem)))
-                        .addResources(org.apache.mesos.v1.Protos.Resource.newBuilder()
+                            .setType(Value.Type.SCALAR)
+                            .setScalar(Value.Scalar.newBuilder().setValue(mem)))
+                        .addResources(Resource.newBuilder()
                             .setName("disk")
                             .setRole("*")
-                            .setType(org.apache.mesos.v1.Protos.Value.Type.SCALAR)
-                            .setScalar(org.apache.mesos.v1.Protos.Value.Scalar.newBuilder().setValue(disk)))
+                            .setType(Value.Type.SCALAR)
+                            .setScalar(Value.Scalar.newBuilder().setValue(disk)))
                         .build()
                 ))
             )
             .build();
+    }
+
+    @NotNull
+    public static Protos.Call subscribe(
+        @NotNull final String frameworkId,
+        @NotNull final String user,
+        @NotNull final String frameworkName
+    ) {
+        final FrameworkID frameworkID = FrameworkID.newBuilder().setValue(frameworkId).build();
+        return Protos.Call.newBuilder()
+            .setFrameworkId(frameworkID)
+            .setType(Protos.Call.Type.SUBSCRIBE)
+            .setSubscribe(
+                Protos.Call.Subscribe.newBuilder()
+                    .setFrameworkInfo(
+                        FrameworkInfo.newBuilder()
+                            .setId(frameworkID)
+                            .setUser(user)
+                            .setName(frameworkName)
+                            .setFailoverTimeout(0)
+                            .build()
+                    )
+            )
+            .build();
+
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -115,11 +115,6 @@
             </dependency>
             <dependency>
                 <groupId>org.apache.mesos.rx.java</groupId>
-                <artifactId>mesos-rxjava-recordio</artifactId>
-                <version>0.1.0-SNAPSHOT</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.mesos.rx.java</groupId>
                 <artifactId>mesos-rxjava-test</artifactId>
                 <version>0.1.0-SNAPSHOT</version>
                 <scope>test</scope>


### PR DESCRIPTION
Creation of a MesosSchedulerClient is now managed via the new
MesosSchedulerClientBuilder class. This class provides all the necessary
methods to construct a MesosSchedulerClient.

MesosSchedulerClient has been refactored to instead of returning a raw
`Observable<Protos.Event>` it instead task a
`Function<Observable<Protos.Event>, Observable<Optional<SinkOperation<Protos.Call>>>`.
This function will be woven into the event stream for the user. This
change affords us much greater control over the lifecycle of the event
stream and subscriptions on the end of it.

When the event stream is opened an `AwaitableSubscription` will be
returned to the user which can be used to await the end of the stream
(either error or complete). If the stream ends due to an error, the
error will be propagated to the thread blocked by the `await()` call.

Create a new utility TcpSocketProxy that can be used in tests. This
simple proxy allows for the creation of a proxy between two addresses.
The user can then close all sockets immediately or defer to a latter
point.