### PR TITLE
Oracle javadoc fixes

### DIFF
--- a/mesos-rxjava-core/src/main/java/com/mesosphere/mesos/rx/java/AwaitableSubscription.java
+++ b/mesos-rxjava-core/src/main/java/com/mesosphere/mesos/rx/java/AwaitableSubscription.java
@@ -22,7 +22,7 @@ import rx.Subscription;
 /**
  * A sub-interface of {@link Subscription} that provides the definition of a subscription that can be
  * awaited.
- * <p/>
+ * <p>
  * This is useful for an application that wants to start up an event stream and block its main thread
  * until the event stream has completed.
  */
@@ -33,6 +33,7 @@ public interface AwaitableSubscription extends Subscription {
      * If the {@code rx.Observable} ends due to  {@link Subscriber#onError(Throwable) onError} the {@code Throwable}
      * delivered to {@code onError} will be rethrown. If the {@code rx.Observable} ends by
      * {@link Subscriber#onCompleted() onCompleted} the method will complete cleanly.
+     * @throws Throwable If the stream terminates due to any Throwable, it will be re-thrown from this method
      */
     void await() throws Throwable;
 

--- a/mesos-rxjava-core/src/main/java/com/mesosphere/mesos/rx/java/MesosSchedulerClientBuilder.java
+++ b/mesos-rxjava-core/src/main/java/com/mesosphere/mesos/rx/java/MesosSchedulerClientBuilder.java
@@ -27,7 +27,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Builder used to create a {@link MesosSchedulerClient}.
- * <p/>
+ * <p>
  * PLEASE NOTE: All methods in this class function as "set" rather than "copy with new value"
  * @param <Send>       The type of objects that will be sent to Mesos
  * @param <Receive>    The type of objects are expected from Mesos
@@ -44,10 +44,10 @@ public final class MesosSchedulerClientBuilder<Send, Receive> {
     private MesosSchedulerClientBuilder() {}
 
     /**
-     * Create a new instance of {@link MesosSchedulerClientBuilder}
+     * Create a new instance of MesosSchedulerClientBuilder
      * @param <Send>       The type of objects that will be sent to Mesos
      * @param <Receive>    The type of objects are expected from Mesos
-     * @return A new instance of {@link MesosSchedulerClientBuilder}
+     * @return A new instance of MesosSchedulerClientBuilder
      */
     @NotNull
     public static <Send, Receive> MesosSchedulerClientBuilder<Send, Receive> newBuilder() {
@@ -130,25 +130,25 @@ public final class MesosSchedulerClientBuilder<Send, Receive> {
 
     /**
      * This method provides the means for a user to define how the event stream will be processed.
-     * <p/>
+     * <p>
      * The function passed to this method will function as the actual event processing code for the user.
-     * <p/>
+     * <p>
      * The stream the users will source from is an {@link Observable} of {@code Receive}s. With this stream
      * source a number of functions can be applied to transform/interact/evaluate the stream.
-     * <p/>
+     * <p>
      * The output of this function represents the users reaction to each event represented as an
      * {@code Observable<Optional<SinkOperation<Send>>>}. If {@link Optional#isPresent()} the specified
      * {@link SinkOperation} will be processed.
-     * <p/>
+     * <p>
      * For example, if you wanted to log all tasks that result in error:
-     * <pre><code>
+     * <pre>{@code
      * events -> {
-     *     final Observable&lt;Optional&lt;SinkOperation&lt;Call>>> errorLogger = events
+     *     final Observable<Optional<SinkOperation<Call>>> errorLogger = events
      *         .filter(event -> event.getType() == Event.Type.UPDATE && event.getUpdate().getStatus().getState() == TaskState.TASK_ERROR)
      *         .doOnNext(e -> LOGGER.warn("Task Error: {}", ProtoUtils.protoToString(e)))
      *         .map(e -> Optional.empty());
      * }
-     * </code></pre>
+     * }</pre>
      * @param streamProcessing    The function that will be woven between the event spout and the call sink
      * @return this builder (allowing for further chained calls)
      */

--- a/mesos-rxjava-core/src/main/java/com/mesosphere/mesos/rx/java/MessageCodec.java
+++ b/mesos-rxjava-core/src/main/java/com/mesosphere/mesos/rx/java/MessageCodec.java
@@ -44,6 +44,8 @@ public interface MessageCodec<T> {
      *
      * @param bytes the bytes to deserialize
      * @return the deserialized message
+     * @throws RuntimeException If an error occurs when decoding {@code bytes}. If a checked exception is possible
+     *                          it should be wrapped in a RuntimeException.
      */
     @NotNull
     T decode(@NotNull final byte[] bytes);

--- a/mesos-rxjava-core/src/main/java/com/mesosphere/mesos/rx/java/ProtoCodec.java
+++ b/mesos-rxjava-core/src/main/java/com/mesosphere/mesos/rx/java/ProtoCodec.java
@@ -31,7 +31,7 @@ public final class ProtoCodec<T extends Message> implements MessageCodec<T> {
     private final Parser<T> parser;
 
     /**
-     * Instantiates a {@link ProtoCodec} instance that deserializes messages with the given
+     * Instantiates a ProtoCodec instance that deserializes messages with the given
      * {@link com.mesosphere.mesos.rx.java.ProtoCodec.Parser}.
      * <p>
      * The specific parser that is provided defines which protobuf message class this codec is for. For example,
@@ -44,20 +44,12 @@ public final class ProtoCodec<T extends Message> implements MessageCodec<T> {
         this.parser = parser;
     }
 
-    /**
-     * @inheritDoc
-     */
     @NotNull
     @Override
     public byte[] encode(@NotNull final T message) {
         return message.toByteArray();
     }
 
-    /**
-     * @inheritDoc
-     *
-     * @throws RuntimeException if an error occurs when parsing the protobuf
-     */
     @NotNull
     @Override
     public T decode(@NotNull byte[] bytes) {
@@ -68,18 +60,12 @@ public final class ProtoCodec<T extends Message> implements MessageCodec<T> {
         }
     }
 
-    /**
-     * @inheritDoc
-     */
     @NotNull
     @Override
     public String mediaType() {
         return "application/x-protobuf";
     }
 
-    /**
-     * @inheritDoc
-     */
     @NotNull
     @Override
     public String show(@NotNull final T message) {

--- a/mesos-rxjava-core/src/main/java/com/mesosphere/mesos/rx/java/Rx.java
+++ b/mesos-rxjava-core/src/main/java/com/mesosphere/mesos/rx/java/Rx.java
@@ -29,7 +29,7 @@ public final class Rx {
 
     /**
      * This method will return the {@link Scheduler} that is used for all "computation" workloads.
-     * <p/>
+     * <p>
      * The idea of a computation workload is one that is CPU bound.
      * @return The {@link Scheduler} that is to be used for all CPU bound workloads.
      */
@@ -40,7 +40,7 @@ public final class Rx {
 
     /**
      * This method will return the {@link Scheduler} that is used for all "io" workloads.
-     * <p/>
+     * <p>
      * The idea of a io workload is one that is IO bound (disk, network, etc.).
      * @return The {@link Scheduler} that is to be used for all IO bound workloads.
      */

--- a/mesos-rxjava-core/src/main/java/com/mesosphere/mesos/rx/java/SinkOperation.java
+++ b/mesos-rxjava-core/src/main/java/com/mesosphere/mesos/rx/java/SinkOperation.java
@@ -27,15 +27,15 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * to Mesos.  The current implementation of Mesos is such that any call to its HTTP API with a
  * {@link org.apache.mesos.v1.scheduler.Protos.Call} that isn't a
  * {@link org.apache.mesos.v1.scheduler.Protos.Call.Type#SUBSCRIBE} will result in a semi-blocking response.
- * <p/>
+ * <p>
  * This means things like request validation (including body deserialization and field validation) are
  * performed synchronously during the request. Due to this behavior, this class exists to inform the
  * user of the success or failure of requests sent to the master.
- * <p/>
+ * <p>
  * It should be noted that this object doesn't represent the means of detecting and handling connection errors
  * with Mesos as the intent is that it will be communicated to the whole event stream rather than an
  * individual {@link org.apache.mesos.v1.scheduler.Protos.Call}.
- * <p/>
+ * <p>
  * <i>NOTE</i>
  * The semantics of which thread a callback will be invoked on are undefined and should not be relied upon.
  * This means that all standard thread safety/guards should be in place for state changes that take place

--- a/mesos-rxjava-core/src/main/java/com/mesosphere/mesos/rx/java/package-info.java
+++ b/mesos-rxjava-core/src/main/java/com/mesosphere/mesos/rx/java/package-info.java
@@ -18,7 +18,7 @@
  * coming from Apache Mesos.
  *
  * The following is a full Apache Mesos Framework that declines all resource offers:
- * <pre><code>
+ * <pre>{@code
  * import static org.apache.mesos.v1.Protos.*;
  * import static org.apache.mesos.v1.scheduler.Protos.*;
  *
@@ -61,6 +61,6 @@
  *     .build()
  *     .openStream()
  *     .await();
- * </code></pre>
+ * }</pre>
  */
 package com.mesosphere.mesos.rx.java;

--- a/mesos-rxjava-example/mesos-rxjava-example-framework/src/main/java/com/mesosphere/mesos/rx/java/example/framework/sleepy/LegacySleepy.java
+++ b/mesos-rxjava-example/mesos-rxjava-example-framework/src/main/java/com/mesosphere/mesos/rx/java/example/framework/sleepy/LegacySleepy.java
@@ -42,11 +42,11 @@ public final class LegacySleepy implements Scheduler {
     private static final Logger LOGGER = LoggerFactory.getLogger(LegacySleepy.class);
 
     /**
-     * <pre><code>
-     * Usage: java -cp &lt;application-jar> com.mesosphere.mesos.rx.java.example.framework.sleepy.LegacySleepy &lt;mesos-zk-uri> &lt;cpus-per-task>
+     * <pre>{@code
+     * Usage: java -cp <application-jar> com.mesosphere.mesos.rx.java.example.framework.sleepy.LegacySleepy <mesos-zk-uri> <cpus-per-task>
      * mesos-zk-uri     The fully qualified URI to the Mesos Master. (zk://localhost:2181/mesos)
      * cpus-per-task    The number of CPUs each task should claim from an offer.
-     * </code></pre>
+     * }</pre>
      * @param args    Application arguments mesos-uri and cpus-per-task.
      */
     public static void main(String[] args) {

--- a/mesos-rxjava-example/mesos-rxjava-example-framework/src/main/java/com/mesosphere/mesos/rx/java/example/framework/sleepy/Sleepy.java
+++ b/mesos-rxjava-example/mesos-rxjava-example-framework/src/main/java/com/mesosphere/mesos/rx/java/example/framework/sleepy/Sleepy.java
@@ -47,11 +47,11 @@ public final class Sleepy {
     private static final Logger LOGGER = LoggerFactory.getLogger(Sleepy.class);
 
     /**
-     * <pre><code>
-     * Usage: java -cp &lt;application-jar> com.mesosphere.mesos.rx.java.example.framework.sleepy.Sleepy &lt;mesos-uri> &lt;cpus-per-task>
+     * <pre>{@code
+     * Usage: java -cp <application-jar> com.mesosphere.mesos.rx.java.example.framework.sleepy.Sleepy <mesos-uri> <cpus-per-task>
      * mesos-uri        The fully qualified URI to the Mesos Master. (http://localhost:5050/api/v1/scheduler)
      * cpus-per-task    The number of CPUs each task should claim from an offer.
-     * </code></pre>
+     * }</pre>
      * @param args    Application arguments mesos-uri and cpus-per-task.
      */
     public static void main(final String[] args) {

--- a/mesos-rxjava-example/mesos-rxjava-example-framework/src/main/java/com/mesosphere/mesos/rx/java/example/framework/sleepy/package-info.java
+++ b/mesos-rxjava-example/mesos-rxjava-example-framework/src/main/java/com/mesosphere/mesos/rx/java/example/framework/sleepy/package-info.java
@@ -16,7 +16,7 @@
 
 /**
  * This package contains an example Mesos Framework built on the Mesos RxJava Client.
- * <p/>
+ * <p>
  * The framework defined in this package is pretty rudimentary but does illustrate how to use Mesos RxJava, and some
  * of the best practices that should be employed when creating a framework.
  */

--- a/mesos-rxjava-recordio/src/main/java/com/mesosphere/mesos/rx/java/recordio/RecordIOOperator.java
+++ b/mesos-rxjava-recordio/src/main/java/com/mesosphere/mesos/rx/java/recordio/RecordIOOperator.java
@@ -41,9 +41,6 @@ import static com.google.common.collect.Lists.newArrayList;
  */
 public final class RecordIOOperator implements Operator<byte[], ByteBuf> {
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Subscriber<ByteBuf> call(final Subscriber<? super byte[]> subscriber) {
         return new RecordIOSubscriber(subscriber);


### PR DESCRIPTION
Oracle JDK has more strict rules regarding javadoc generation than OpenJDK does. This build fixes all of the issues identified when Oracle JDK is used.